### PR TITLE
use influxdb08 for now

### DIFF
--- a/munininfluxdb/influxdbclient.py
+++ b/munininfluxdb/influxdbclient.py
@@ -3,7 +3,7 @@ import getpass
 import json
 from collections import defaultdict
 
-import influxdb
+import influxdb.influxdb08 as influxdb
 import rrd
 from utils import ProgressBar, parse_handle, Color, Symbol
 from rrd import read_xml_file


### PR DESCRIPTION
This PR just fixes the import.

After the switch to 0.9, some methods have to be renamed.
- FutureWarning: get_database_list is deprecated, and will be removed in future versions. Please use `InfluxDBClient.get_list_database` instead.
- FutureWarning: switch_db is deprecated, and will be removed in future versions. Please use `InfluxDBClient.switch_database(database)` instead.
